### PR TITLE
Add support for inferring generic type hints

### DIFF
--- a/tests/test_dtypes/test_inference.py
+++ b/tests/test_dtypes/test_inference.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pyarrow as pa
@@ -42,6 +42,8 @@ from elbow.dtypes import DataType, PaJSONType, PaNDArrayType, PaPickleType, get_
         ("pickle", PaPickleType()),
         ("ndarray<float32>", PaNDArrayType(pa.float32())),
         (Optional[str], pa.string()),
+        (List[str], pa.list_(pa.string())),
+        (Dict[str, Any], PaJSONType()),
     ],
 )
 def test_get_dtype(test_input: DataType, expected: pa.DataType):


### PR DESCRIPTION
When records are defined via dataclasses, it's nice to be able to specify types through python's native type hints. This PR adds some initial support for this:

- Optional types like `Optional[str]`
- List types like `List[int]`
- Arbitrary records `Dict[str, Any]`, which are cast to our pyarrow json extension type.