### PR TITLE
Refactor loaders and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Elbow is a library for extracting data from a bunch of files and loading into a 
 ```python
 import json
 
-from elbow import load_table, load_parquet
+from elbow import build_table, build_parquet
 
 # Extract records from JSON-lines
 def extract(path):
@@ -21,16 +21,16 @@ def extract(path):
             yield record
 
 # Load as a pandas dataframe
-df = load_table(
+df = build_table(
     source="**/*.json",
     extract=extract,
 )
 
 # Load as a parquet dataset (in parallel)
-dset = load_parquet(
+dset = build_parquet(
     source="**/*.json",
     extract=extract,
-    where="dset.parquet",
+    where="dset/",
     workers=8,
 )
 ```

--- a/benchmarks/json/benchmark.py
+++ b/benchmarks/json/benchmark.py
@@ -2,7 +2,7 @@ import tempfile
 import time
 from pathlib import Path
 
-from elbow.loaders import load_parquet
+from elbow.builders import build_parquet
 from tests.utils_for_tests import extract_jsonl
 
 DATASET_SIZE_MB = 17.8
@@ -15,7 +15,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     where = Path(tmpdir) / "fake_json.parquet"
 
     tic = time.monotonic()
-    dset = load_parquet(
+    dset = build_parquet(
         source=source,
         extract=extract_jsonl,
         where=where,

--- a/elbow/__init__.py
+++ b/elbow/__init__.py
@@ -3,6 +3,6 @@ Extract data from a bunch of files and load into a table.
 """
 
 from ._version import __version__, __version_tuple__  # noqa
-from .loaders import *  # noqa
+from .builders import *  # noqa
 from .pipeline import *  # noqa
 from .record import *  # noqa


### PR DESCRIPTION
- Rename `loaders` -> `builders`. Although the L stands for load in ETL, the term is always confusing.
- Improve parallel parquet generation error handling.
- Add ".parquet" extension to partition files so they can be loaded in dask.
- Remove empty partition files to avoid an empty file error on read.
- Add overwrite option.