### PR TITLE
Make parquet builder more parallelizable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,8 @@ repos:
     -   id: trailing-whitespace
     -   id: check-ast
     -   id: check-merge-conflict
-    # -   id: no-commit-to-branch
-    #     args: ['--branch=main']
+    -   id: no-commit-to-branch
+        args: ['--branch=main']
     -   id: end-of-file-fixer
 
 -   repo: https://github.com/psf/black

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Elbow is a library for extracting data from a bunch of files and loading into a 
 ```python
 import json
 
+import pandas as pd
 from elbow import build_table, build_parquet
 
 # Extract records from JSON-lines
@@ -27,12 +28,14 @@ df = build_table(
 )
 
 # Load as a parquet dataset (in parallel)
-dset = build_parquet(
+build_parquet(
     source="**/*.json",
     extract=extract,
-    where="dset/",
+    where="dset.pqds/",
     workers=8,
 )
+
+df = pd.read_parquet("dset.pqds")
 ```
 
 ## Installation

--- a/benchmarks/json/benchmark.py
+++ b/benchmarks/json/benchmark.py
@@ -2,9 +2,12 @@ import tempfile
 import time
 from pathlib import Path
 
+import pandas as pd
+
 from elbow.builders import build_parquet
 from tests.utils_for_tests import extract_jsonl
 
+# TODO: do I need to hardcode this?
 DATASET_SIZE_MB = 17.8
 
 
@@ -12,15 +15,17 @@ dataset_path = Path(__file__).parent / "data"
 source = str(dataset_path / "*.json")
 
 with tempfile.TemporaryDirectory() as tmpdir:
-    where = Path(tmpdir) / "fake_json.parquet"
+    where = Path(tmpdir) / "fake_json.pqds"
 
     tic = time.monotonic()
-    dset = build_parquet(
+    build_parquet(
         source=source,
         extract=extract_jsonl,
         where=where,
     )
     runtime = time.monotonic() - tic
 
+    df = pd.read_parquet(where)
+
     tput = DATASET_SIZE_MB / runtime
-    print(f"JSON benchmark throughput: {tput:.2f} MB/s")
+    print(f"JSON benchmark:  rows written: {len(df)}, throughput: {tput:.2f} MB/s")

--- a/elbow/builders.py
+++ b/elbow/builders.py
@@ -56,10 +56,10 @@ def build_parquet(
     extract: Extractor,
     where: StrOrPath,
     *,
-    incremental: bool = False,
     workers: Optional[int] = None,
-    max_failures: Optional[int] = 0,
+    incremental: bool = False,
     overwrite: bool = False,
+    max_failures: Optional[int] = 0,
     worker_id: Optional[int] = None,
 ) -> None:
     """
@@ -70,12 +70,12 @@ def build_parquet(
             Patterns containing '**' will match any files and zero or more directories
         extract: extract function mapping file paths to records
         where: path to output parquet dataset directory
-        incremental: update dataset incrementally with only new or changed files.
         workers: number of parallel processes. If `None` or 1, run in the main
             process. Setting to <= 0 runs as many processes as there are cores
             available.
-        max_failures: number of failures to tolerate
+        incremental: update dataset incrementally with only new or changed files.
         overwrite: overwrite previous results.
+        max_failures: number of extract failures to tolerate
         worker_id: optional worker ID to use when scheduling parallel tasks externally.
             Specifying the number of workers is required in this case. Incompatible with
             overwrite.

--- a/elbow/builders.py
+++ b/elbow/builders.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import shutil
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime
@@ -9,8 +8,6 @@ from pathlib import Path
 from typing import Iterable, Optional, Union
 
 import pandas as pd
-import pyarrow.parquet as pq
-from pyarrow import ArrowInvalid
 
 from elbow.extractors import Extractor
 from elbow.filters import FileModifiedIndex, hash_partitioner
@@ -18,7 +15,7 @@ from elbow.pipeline import Pipeline
 from elbow.record import RecordBatch
 from elbow.sinks import BufferedParquetWriter
 from elbow.typing import StrOrPath
-from elbow.utils import atomicopen
+from elbow.utils import atomicopen, cpu_count
 
 __all__ = ["build_table", "build_parquet"]
 
@@ -26,6 +23,7 @@ __all__ = ["build_table", "build_parquet"]
 def build_table(
     source: Union[str, Iterable[StrOrPath]],
     extract: Extractor,
+    *,
     max_failures: Optional[int] = 0,
 ) -> pd.DataFrame:
     """
@@ -57,11 +55,13 @@ def build_parquet(
     source: Union[str, Iterable[StrOrPath]],
     extract: Extractor,
     where: StrOrPath,
+    *,
     incremental: bool = False,
     workers: Optional[int] = None,
     max_failures: Optional[int] = 0,
     overwrite: bool = False,
-) -> pq.ParquetDataset:
+    worker_id: Optional[int] = None,
+) -> None:
     """
     Extract records from a stream of files and load as a Parquet dataset
 
@@ -72,28 +72,37 @@ def build_parquet(
         where: path to output parquet dataset directory
         incremental: update dataset incrementally with only new or changed files.
         workers: number of parallel processes. If `None` or 1, run in the main
-            process. Setting to -1 runs in `os.cpu_count()` processes.
+            process. Setting to <= 0 runs as many processes as there are cores
+            available.
         max_failures: number of failures to tolerate
-        overwrite: overwrite previous results
-
-    Returns:
-        A PyArrow ParquetDataset handle to the loaded dataset
+        overwrite: overwrite previous results.
+        worker_id: optional worker ID to use when scheduling parallel tasks externally.
+            Specifying the number of workers is required in this case. Incompatible with
+            overwrite.
     """
     # TODO:
     #     - generalize sources
     #     - parallel extraction is a bit awkward due to hashing assignment might consider
-    #       pre-expanding the sources and partitioning.
+    #       pre-expanding the sources and partitioning. But this is susceptible to racing.
 
     if not incremental and Path(where).exists():
         if overwrite:
+            if worker_id is not None:
+                raise FileExistsError(
+                    f"Parquet output directory {where} already exists; "
+                    "can't overwrite when using worker_id"
+                )
             shutil.rmtree(where)
         else:
             raise FileExistsError(f"Parquet output directory {where} already exists")
 
-    if workers is None or workers == 0:
+    if worker_id is not None:
+        if workers is None or workers <= 0:
+            raise ValueError("workers >= 0 is required when passing worker_id")
+    elif workers is None:
         workers = 1
-    elif workers < 0:
-        workers = os.cpu_count()
+    elif workers <= 0:
+        workers = cpu_count()
 
     _worker = partial(
         _build_parquet_worker,
@@ -105,7 +114,11 @@ def build_parquet(
         max_failures=max_failures,
     )
 
-    if workers > 1:
+    if workers == 1:
+        _worker(0)
+    elif worker_id is not None:
+        _worker(worker_id)
+    else:
         with ProcessPoolExecutor(workers) as pool:
             futures_to_id = {pool.submit(_worker, ii): ii for ii in range(workers)}
 
@@ -117,15 +130,6 @@ def build_parquet(
                     logging.warning(
                         "Generated exception in worker %d", worker_id, exc_info=exc
                     )
-    else:
-        _worker(0)
-
-    try:
-        dset = pq.ParquetDataset(where)
-    except (FileNotFoundError, ArrowInvalid):
-        raise RuntimeError("Build parquet pipeline failed")
-
-    return dset
 
 
 def _build_parquet_worker(

--- a/elbow/utils.py
+++ b/elbow/utils.py
@@ -158,3 +158,14 @@ def detect_size_units(size: Union[int, float]) -> Tuple[float, str]:
         return size / 1e6, "MB"
     else:
         return size / 1e9, "GB"
+
+
+def cpu_count() -> int:
+    """
+    Get the number of available CPUs.
+    """
+    if "SLURM_CPUS_ON_NODE" in os.environ:
+        count = int(os.environ["SLURM_CPUS_ON_NODE"])
+    else:
+        count = os.cpu_count() or 1
+    return count

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -2,8 +2,8 @@ import time
 from pathlib import Path
 
 import pytest
-from pytest_benchmark.fixture import BenchmarkFixture
 from pyarrow import parquet as pq
+from pytest_benchmark.fixture import BenchmarkFixture
 
 from elbow import build_parquet, build_table
 from tests.utils_for_tests import extract_jsonl, random_jsonl_batch

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -69,9 +69,7 @@ def test_build_parquet(jsonl_dataset: str, mod_tmp_path: Path):
 def test_build_parquet_parallel(jsonl_dataset: str, mod_tmp_path: Path):
     pq_path = mod_tmp_path / "dset_parallel.parquet"
 
-    build_parquet(
-        source=jsonl_dataset, extract=extract_jsonl, where=pq_path, workers=2
-    )
+    build_parquet(source=jsonl_dataset, extract=extract_jsonl, where=pq_path, workers=2)
     dset = pq.ParquetDataset(pq_path)
     assert len(dset.files) == 2
 


### PR DESCRIPTION
Add an option to pass a `worker_id` to `build_parquet()`, to support scheduling parallel build tasks externally (e.g. in SLURM or dask).