### PR TITLE
Just delete empty files in `atomicopen()`

### DIFF
--- a/elbow/utils.py
+++ b/elbow/utils.py
@@ -110,7 +110,11 @@ def atomicopen(path: StrOrPath, mode: str = "w", **kwargs):
         raise exc
     else:
         file.close()
-        os.replace(file.name, path)
+        # don't bother replacing if we didn't end up writing anything
+        if os.stat(file.name).st_size > 0:
+            os.replace(file.name, path)
+        else:
+            os.remove(file.name)
 
 
 def parse_size(size: str) -> int:


### PR DESCRIPTION
Sometimes we get empty partition files in `build_parquet()` if a worker never generates any records. Avoid getting an empty file error by not even writing these files out.