### PR TITLE
Rename file metadata extractor

### DIFF
--- a/elbow/extractors/__init__.py
+++ b/elbow/extractors/__init__.py
@@ -1,2 +1,2 @@
-from .base import *  # noqa
-from .meta import *  # noqa
+from .base import Extractor  # noqa
+from .file_meta import FileMetadata, extract_file_meta  # noqa

--- a/elbow/extractors/file_meta.py
+++ b/elbow/extractors/file_meta.py
@@ -7,8 +7,6 @@ from typing import Optional
 
 from elbow.typing import StrOrPath
 
-__all__ = ["FileMetadata", "file_meta"]
-
 
 @dataclass
 class FileMetadata:
@@ -23,7 +21,7 @@ class FileMetadata:
     mod_time: Optional[float]
 
 
-def file_meta(path: StrOrPath) -> FileMetadata:
+def extract_file_meta(path: StrOrPath) -> FileMetadata:
     """
     File metadata extractor.
     """

--- a/tests/test_extractors/test_meta.py
+++ b/tests/test_extractors/test_meta.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from elbow.extractors import file_meta
+from elbow.extractors import extract_file_meta
 
 
 @pytest.fixture
@@ -15,8 +15,8 @@ def json_path(tmp_path: Path) -> Path:
     return json_path
 
 
-def test_file_meta(json_path: Path):
-    metadata = file_meta(json_path)
+def test_extract_file_meta(json_path: Path):
+    metadata = extract_file_meta(json_path)
 
     assert metadata.file_path == str(json_path.absolute())
     assert metadata.link_target is None
@@ -25,7 +25,7 @@ def test_file_meta(json_path: Path):
     link_path = json_path.parent / "link.json"
     os.symlink(json_path, link_path)
 
-    metadata = file_meta(link_path)
+    metadata = extract_file_meta(link_path)
     assert metadata.file_path == str(link_path.absolute())
     assert metadata.link_target == str(json_path.absolute())
     assert metadata.mod_time > 1672549200

--- a/tests/test_filters/test_meta.py
+++ b/tests/test_filters/test_meta.py
@@ -4,7 +4,7 @@ from typing import List
 import pyarrow.parquet as pq
 import pytest
 
-from elbow.extractors import file_meta
+from elbow.extractors import extract_file_meta
 from elbow.filters import FileModifiedIndex
 from elbow.record import RecordBatch
 
@@ -25,7 +25,7 @@ def file_index_parquet(tmp_path: Path, dummy_files: List[Path]) -> Path:
 
     index = RecordBatch()
     for path in dummy_files:
-        metadata = file_meta(path)
+        metadata = extract_file_meta(path)
         index.append(metadata)
 
     index = index.to_arrow()

--- a/tests/utils_for_tests.py
+++ b/tests/utils_for_tests.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 import numpy as np
 
-from elbow.extractors import file_meta
+from elbow.extractors import extract_file_meta
 from elbow.record import as_record
 from elbow.typing import StrOrPath
 
@@ -36,7 +36,7 @@ def random_string(rng: np.random.Generator, length: int):
 
 
 def extract_jsonl(path: StrOrPath):
-    metadata = as_record(file_meta(path))
+    metadata = as_record(extract_file_meta(path))
 
     with open(path) as f:
         for line in f:


### PR DESCRIPTION
Rename `file_meta()` -> `extract_file_meta()` to be a little more explicit.