### PR TITLE
Make filesystem crawl source picklable

### DIFF
--- a/elbow/sources/__init__.py
+++ b/elbow/sources/__init__.py
@@ -1,1 +1,0 @@
-from .filesystem import *  # noqa

--- a/tests/test_sources/test_filesystem.py
+++ b/tests/test_sources/test_filesystem.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from elbow.sources import crawldir
+from elbow.sources.filesystem import Crawler
 
 
 @pytest.fixture
@@ -20,8 +20,8 @@ def dummy_tree(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_crawldirs(dummy_tree: Path):
-    paths = crawldir(
+def test_crawler(dummy_tree: Path):
+    paths = Crawler(
         root=dummy_tree,
         include=["*.txt", "*.json"],
         exclude=["b.txt"],


### PR DESCRIPTION
Generators are not picklable, so a raw generator source can't be used in `build_parquet()` with `workers > 1`. Instead, we now wrap the crawling logic in a picklable class.