### PR TITLE
Remove use of fcntl

### DIFF
--- a/elbow/utils.py
+++ b/elbow/utils.py
@@ -1,4 +1,3 @@
-import fcntl
 import logging
 import os
 import re
@@ -69,22 +68,6 @@ def setup_logging(
     # https://stackoverflow.com/a/7430495
     # But I want the convenience to just call e.g. `logging.info()`.
     logging.root = logger  # type: ignore
-
-
-@contextmanager
-def lockopen(path: StrOrPath, mode: str = "w", **kwargs):
-    """
-    Open a file with an exclusive lock.
-
-    See also: https://github.com/dmfrey/FileLock/blob/master/filelock/filelock.py
-    """
-    file = open(path, mode, **kwargs)
-    fcntl.flock(file.fileno(), fcntl.LOCK_EX)
-    try:
-        yield file
-    finally:
-        fcntl.flock(file.fileno(), fcntl.LOCK_UN)
-        file.close()
 
 
 @contextmanager

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,5 @@
 # pylint: disable=redefined-outer-name
 import logging
-import time
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -15,30 +13,6 @@ def test_repetitive_filter():
     # default logger already contains the repetitive filter
     for ii in range(10):
         logging.warning("Message: %d", ii)
-
-
-def test_lockopen(tmp_path: Path):
-    fname = tmp_path / "file.txt"
-
-    def _task(task_id: int):
-        with ut.lockopen(fname, mode="a+") as f:
-            t = time.time()
-            lines = f.readlines()
-            last_line = lines[-1] if lines else ""
-            new_line = f"id={task_id}, t={t}"
-            logging.debug(f"last line={last_line}\tnew line={new_line}")
-            time.sleep(0.01)
-            print(new_line, file=f)
-        return task_id
-
-    num_tasks = 10
-    pool = ThreadPoolExecutor(4)
-    for task_id in pool.map(_task, range(num_tasks)):
-        logging.debug(f"Done {task_id}")
-
-    with open(fname) as f:
-        lines = f.readlines()
-    assert len(lines) == num_tasks
 
 
 def test_atomicopen(tmp_path: Path):


### PR DESCRIPTION
fcntl is not supported in windows. It was only used in the `lockopen` util function which itself was not used.